### PR TITLE
Install git in builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7
 RUN yum install -y openssh-server which
 
 # These are common dependencies so installing them here makes builds faster
-RUN yum install -y autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign
+RUN yum install -y autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign git
 
 RUN yes centos | passwd root
 


### PR DESCRIPTION
Apparently some of our gems will shell out to git to figure out what files to exclude 🙃  https://github.com/puppetlabs/orchestrator_client-ruby/blob/434457b5823c14d446560db607634577d5e694e7/orchestrator_client.gemspec#L11